### PR TITLE
feat: add webassembly plugins, attempt 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli 0.27.3",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli 0.28.0",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +45,12 @@ checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android-tzdata"
@@ -82,10 +123,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "async-trait"
+version = "0.1.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
 
 [[package]]
 name = "autocfg"
@@ -94,10 +152,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line 0.21.0",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.32.0",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -112,10 +200,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "cap-fs-ext"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b779b2d0a001c125b4584ad586268fb4b92d957bff8d26d7fe0dd78283faa814"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 2.0.2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf30c373a3bee22c292b1b6a7a26736a38376840f1af3d2d806455edf8c3899"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 2.0.2",
+ "ipnet",
+ "maybe-owned",
+ "rustix 0.38.8",
+ "windows-sys 0.48.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577de6cff7c2a47d6b13efe5dd28bf116bd7f8f7db164ea95b7cc2640711f522"
+dependencies = [
+ "ambient-authority",
+ "rand",
+]
+
+[[package]]
+name = "cap-std"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bade423fa6403efeebeafe568fdb230e8c590a275fba2ba978dd112efcf6e9"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 2.0.2",
+ "rustix 0.38.8",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f52b3c8f4abfe3252fd0a071f3004aaa3b18936ec97bdbd8763ce03aff6247"
+dependencies = [
+ "cap-primitives",
+ "once_cell",
+ "rustix 0.38.8",
+ "winx",
+]
 
 [[package]]
 name = "cc"
@@ -123,6 +295,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -179,7 +352,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -210,6 +383,141 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7348010242a23d0285e5f852f13b07f9540a50f13ab6e92fd047b88490bf5ee"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38849e3b19bc9a6dbf8bc188876b76e6ba288089a5567be573de50f44801375c"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.27.3",
+ "hashbrown 0.13.2",
+ "log",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3de51da572e65cb712a47b7413c50208cac61a4201560038de929d9a7f4fadf"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75f869ae826055a5064d4a400abde7806eb86d89765dbae51d42846df23121a"
+
+[[package]]
+name = "cranelift-control"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf6631316ad6ccfd60055740ad25326330d31407a983a454e45c5a62f64d101"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1d6a38935ee64551a7c8da4cc759fdcaba1d951ec56336737c0459ed5a05d2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73c410c2d52e28fc4b49aab955a1c2f58580ff37a3b0641e23bccd6049e4b5"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61acaa7646020e0444bb3a22d212a5bae0e3b3969b18e1276a037ccd6493a8fd"
+
+[[package]]
+name = "cranelift-native"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543f52ef487498253ebe5df321373c5c314da74ada0e92f13451b6f887194f87"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788c27f41f31a50a9a3546b91253ad9495cd54df0d6533b3f3dcb4fb7a988f69"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "itertools",
+ "log",
+ "smallvec",
+ "wasmparser 0.110.0",
+ "wasmtime-types",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam"
@@ -304,6 +612,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +654,15 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -386,6 +713,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +749,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -413,10 +780,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -450,14 +845,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fd-lock"
 version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.8",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "fd-lock"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
+dependencies = [
+ "cfg-if",
+ "rustix 0.38.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "file-per-thread-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3cc21c33af89af0930c8cae4ade5e6fdc17b5d2c97b3d2e2edb67a1cf683f3"
+dependencies = [
+ "env_logger",
+ "log",
 ]
 
 [[package]]
@@ -467,10 +889,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs-err"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd738b84894214045e8414eaded76359b4a5773f0a0a56b16575110739cdcf39"
+dependencies = [
+ "io-lifetimes 2.0.2",
+ "rustix 0.38.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
 
 [[package]]
 name = "fuzzy-matcher"
@@ -479,6 +982,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags 2.4.0",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -491,6 +1039,44 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 1.9.3",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
@@ -512,6 +1098,12 @@ checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -537,10 +1129,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+ "serde",
+]
+
+[[package]]
+name = "io-extras"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3c230ee517ee76b1cc593b52939ff68deda3fae9e41eca426c6b4993df51c4"
+dependencies = [
+ "io-lifetimes 2.0.2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb4def18c48926ccac55c1223e02865ce1a821751a95920448662696e7472c"
+
+[[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
@@ -549,8 +1211,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "rustix 0.38.8",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "ittapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e0d0b7b3b53d92a7e8b80ede3400112a6b8b4c98d1f5b8b16bb787c780582c"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f8763c96e54e6d6a0dccc2990d8b5e33e3313aaeae6185921a3f4c1614a77c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -569,10 +1275,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -600,10 +1318,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "pin-utils",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memfd"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
+dependencies = [
+ "rustix 0.37.23",
+]
 
 [[package]]
 name = "memoffset"
@@ -621,6 +1386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -682,6 +1456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,10 +1485,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.13.2",
+ "indexmap 1.9.3",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "oneshot"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc22d22931513428ea6cc089e942d38600e3d00976eef8c86de6b8a3aadec6eb"
+dependencies = [
+ "loom",
+]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -730,10 +1550,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -745,10 +1595,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.26"
+name = "psm"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+dependencies = [
+ "bitflags 1.3.2",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -761,6 +1631,36 @@ checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
  "endian-type",
  "nibble_vec",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -806,6 +1706,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b4dcbd3a2ae7fb94b5813fa0e957c6ab51bf5d0a8ee1b69e0c2d0f1e6eb8485"
+dependencies = [
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hash",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,8 +1726,17 @@ checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.3.6",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -825,8 +1747,14 @@ checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -843,8 +1771,39 @@ dependencies = [
  "clap",
  "crossterm",
  "fs-err",
+ "oneshot",
  "rustyline",
+ "serde",
+ "serde_json",
  "thiserror",
+ "wasmtime",
+ "wasmtime-wasi",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.37.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes 1.0.11",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -855,8 +1814,10 @@ checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
+ "itoa",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.5",
+ "once_cell",
  "windows-sys 0.48.0",
 ]
 
@@ -875,7 +1836,7 @@ dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
  "clipboard-win",
- "fd-lock",
+ "fd-lock 3.0.13",
  "home",
  "libc",
  "log",
@@ -899,8 +1860,20 @@ checksum = "5a32af5427251d2e4be14fc151eabe18abb4a7aad5efee7044da9f096c906a43"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -909,10 +1882,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "serde"
-version = "1.0.183"
+name = "semver"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+
+[[package]]
+name = "serde"
+version = "1.0.187"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7fe14252655bd1e578af19f5fa00fe02fd0013b100ca6b49fde31c41bae4c"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.187"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46b2a6ca578b3f1d4501b12f78ed4692006d79d82a1a7c561c12dbc3d625eb8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "signal-hook"
@@ -970,10 +2003,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -1006,14 +2067,36 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "system-interface"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ce32341b2c0b70c144bbf35627fdc1ef18c76ced5e5e7b3ee8b5ba6b2ab6a0"
+dependencies = [
+ "bitflags 2.4.0",
+ "cap-fs-ext",
+ "cap-std",
+ "fd-lock 4.0.0",
+ "io-lifetimes 2.0.2",
+ "rustix 0.38.8",
+ "windows-sys 0.48.0",
+ "winx",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "term"
@@ -1027,23 +2110,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.40"
+name = "termcolor"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1094,6 +2186,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "tuikit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,10 +2303,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1126,10 +2351,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "url"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vte"
@@ -1165,6 +2425,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi-cap-std-sync"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cef338a20bd9e5e469a37b192b2a954c4dde83ea896c8eaf45df8c84cdf7be5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 2.0.2",
+ "is-terminal",
+ "once_cell",
+ "rustix 0.38.8",
+ "system-interface",
+ "tracing",
+ "wasi-common",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wasi-common"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9c753bdf98fdc592fc729bda2248996f5dd1be71f4e01bf8c08225acb7b6bb"
+dependencies = [
+ "anyhow",
+ "bitflags 2.4.0",
+ "cap-rand",
+ "cap-std",
+ "io-extras",
+ "log",
+ "rustix 0.38.8",
+ "thiserror",
+ "tracing",
+ "wasmtime",
+ "wiggle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,7 +2489,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -1207,7 +2511,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1217,6 +2521,443 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41763f20eafed1399fff1afb466496d3a959f58241436cfdc17e3f5ca954de16"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dfcdb72d96f01e6c85b6bf20102e7423bdbaad5c337301bab2bbf253d26413c"
+dependencies = [
+ "indexmap 2.0.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.111.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad71036aada3f6b09251546e97e4f4f176dd6b41cf6fa55e7e0f65e86aec319a"
+dependencies = [
+ "indexmap 2.0.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8cc41d341939dce08ee902b50e36cd35add940f6044c94b144e8f73fe07a6"
+dependencies = [
+ "anyhow",
+ "wasmparser 0.111.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e38ee12eaafb34198cce001e2ea0a83d3884db5cf8e3af08864f108a2fb57c85"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "bumpalo",
+ "cfg-if",
+ "encoding_rs",
+ "fxprof-processed-profile",
+ "indexmap 2.0.0",
+ "libc",
+ "log",
+ "object 0.31.1",
+ "once_cell",
+ "paste",
+ "psm",
+ "rayon",
+ "serde",
+ "serde_json",
+ "target-lexicon",
+ "wasm-encoder",
+ "wasmparser 0.110.0",
+ "wasmtime-cache",
+ "wasmtime-component-macro",
+ "wasmtime-component-util",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit",
+ "wasmtime-runtime",
+ "wasmtime-winch",
+ "wat",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82313f9dce6f64dd08a7b51bef57411741b7eaef6b4611f77b91b6213a99808b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d22677d863d88d0ee05a07bfe28fdc5525149b6ea5a108f1fa2796fa86d75b8"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bincode",
+ "directories-next",
+ "file-per-thread-logger",
+ "log",
+ "rustix 0.38.8",
+ "serde",
+ "sha2",
+ "toml",
+ "windows-sys 0.48.0",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b6da03d55c656066ebc93d27ce54de11fcd2d3157e7490c6196a65aa1e9bc0"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b54327f9ce6a46c6841c43d93c4fa366cd0beb0f075743b120d31a3d6afe34fd"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d52e14e5453e82708816e992140c59e511bbf7c0868ee654100e2792483f56"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
+ "gimli 0.27.3",
+ "log",
+ "object 0.31.1",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.110.0",
+ "wasmtime-cranelift-shared",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-cranelift-shared"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ddb7f34fff5b4a01aa2e55373fceb1b59d5f981abca44afdd63d7dd39689047"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-native",
+ "gimli 0.27.3",
+ "object 0.31.1",
+ "target-lexicon",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad336809866b743410ac86ec0bdc34899d6f1af5d3deed97188e90503ff527d7"
+dependencies = [
+ "anyhow",
+ "cranelift-entity",
+ "gimli 0.27.3",
+ "indexmap 2.0.0",
+ "log",
+ "object 0.31.1",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasm-encoder",
+ "wasmparser 0.110.0",
+ "wasmprinter",
+ "wasmtime-component-util",
+ "wasmtime-types",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc69f0a316db37482ebc83669236ea7c943d0b49a1a23f763061c9fc9d07d0b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "rustix 0.38.8",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2004b30ea1ad9fd288bce54af19ef08281250e1087f0b5ffc6ca06bacd821edb"
+dependencies = [
+ "addr2line 0.20.0",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpp_demangle",
+ "gimli 0.27.3",
+ "ittapi",
+ "log",
+ "object 0.31.1",
+ "rustc-demangle",
+ "rustix 0.38.8",
+ "serde",
+ "target-lexicon",
+ "wasmtime-environ",
+ "wasmtime-jit-debug",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-runtime",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54aa8081162b13a96f47ab40f9aa03fc02dad38ee10b1418243ac8517c5af6d3"
+dependencies = [
+ "object 0.31.1",
+ "once_cell",
+ "rustix 0.38.8",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2922462d01f5c112bbc4e6eb95ee68447a6031c0b90cc2ad69b890060b3842d9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536c34c4abbe22c40f631067b57ca14d719faf3f63ae0d504014a4d15a4b980b"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "indexmap 2.0.0",
+ "libc",
+ "log",
+ "mach",
+ "memfd",
+ "memoffset 0.9.0",
+ "paste",
+ "rand",
+ "rustix 0.38.8",
+ "sptr",
+ "wasm-encoder",
+ "wasmtime-asm-macros",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit-debug",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wasmtime-types"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec6f1e74eb5ef817043b243eae37cc0e424c256c4069ab2c5afd9f3fe91a12ee"
+dependencies = [
+ "cranelift-entity",
+ "serde",
+ "thiserror",
+ "wasmparser 0.110.0",
+]
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ca36fa6cad8ef885bc27d7d50c8b1cb7da0534251188a824f4953b07875703"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269f4f2192b18037729b617eadb512e95510f1b0cd8fb4990aef286c9bb3dfb9"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.4.0",
+ "bytes",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "futures",
+ "io-extras",
+ "libc",
+ "once_cell",
+ "rustix 0.38.8",
+ "system-interface",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "wasi-cap-std-sync",
+ "wasi-common",
+ "wasmtime",
+ "wiggle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wasmtime-winch"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d016c3f1d0c8ac905bfda51936cb6dae040e0d8edc75b7a1ef9f21773a19f6"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli 0.27.3",
+ "object 0.31.1",
+ "target-lexicon",
+ "wasmparser 0.110.0",
+ "wasmtime-cranelift-shared",
+ "wasmtime-environ",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd55caadebae32cf18541e5077b3f042a171bb9988ea0040d0569f26a63227d"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.0.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wast"
+version = "63.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2560471f60a48b77fccefaf40796fda61c97ce1e790b59dfcec9dc3995c9f63a"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bdc306c2c4c2f2bf2ba69e083731d0d2a77437fc6a350a19db139636e7e416c"
+dependencies = [
+ "wast 63.0.0",
+]
+
+[[package]]
+name = "wiggle"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "166189cd49163adc9a1e2a33b33625eb934d06e518c318905c3a5140d9bc1d45"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.4.0",
+ "thiserror",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67571bd77bff962190744adb29e72a1157d30e8d34fbb2c1c7b0ad7627be020"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "shellexpand",
+ "syn 2.0.29",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5677f7d740bc41f9f6af4a6a719a07fbe1aa8ec66e0ec1ca4d3617f2b27d5361"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+ "wiggle-generate",
+]
 
 [[package]]
 name = "winapi"
@@ -1235,10 +2976,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e6f2f344ec89998f047d0aa3aec77088eb8e33c91f5efdd191b140fda6fa40"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli 0.27.3",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser 0.110.0",
+ "wasmtime-environ",
+]
 
 [[package]]
 name = "windows"
@@ -1380,3 +3146,71 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winx"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857cedf8371f690bb6782a3e2b065c54d1b6661be068aaf3eac8b45e813fdf8"
+dependencies = [
+ "bitflags 2.4.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "541efa2046e544de53a9da1e2f6299e63079840360c9e106f1f8275a97771318"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.0.0",
+ "log",
+ "pulldown-cmark",
+ "semver",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror",
+ "wast 35.0.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,9 @@ fs-err = "2.9.0"
 bitflags = "2.1.0"
 clap = { version = "4.3.24", features = ["derive"] }
 rustyline = { version = "12.0.0", features = ["with-fuzzy", "derive"] }
+# extism = "0.5.0"
+serde = { version = "1.0.187", features = ["derive"] }
+serde_json = "1.0.105"
+wasmtime = "12.0.1"
+wasmtime-wasi = "12.0.1"
+oneshot = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ fs-err = "2.9.0"
 bitflags = "2.1.0"
 clap = { version = "4.3.24", features = ["derive"] }
 rustyline = { version = "12.0.0", features = ["with-fuzzy", "derive"] }
-# extism = "0.5.0"
 serde = { version = "1.0.187", features = ["derive"] }
 serde_json = "1.0.105"
 wasmtime = "12.0.1"

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1,0 +1,56 @@
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+
+use wasmtime::{Caller, Store};
+use wasmtime_wasi::WasiCtx;
+
+use crate::state::shell::ShellState;
+
+use self::memory::manager::WasmMemoryManager;
+
+pub mod host;
+pub mod loader;
+pub mod memory;
+pub mod plugin;
+
+pub type StoreData = Box<dyn PluginContext>;
+
+/// Allows access to the shell and plugin state from inside code exposed to a plugin
+pub trait PluginContext: Send + Sync {
+    fn memory(&self) -> Arc<dyn WasmMemoryManager>;
+    fn set_memory_manager(&mut self, manager: Arc<dyn WasmMemoryManager>);
+    fn wasi(&mut self) -> &mut Option<WasiCtx>;
+    fn shell(&self) -> RwLockReadGuard<'_, ShellState>;
+    fn shell_mut(&mut self) -> RwLockWriteGuard<'_, ShellState>;
+}
+
+pub struct WasmPluginContext {
+    wasi: Option<WasiCtx>,
+    shell: Arc<RwLock<ShellState>>,
+    memory: Option<Arc<dyn WasmMemoryManager>>,
+}
+
+impl PluginContext for WasmPluginContext {
+    fn memory(&self) -> Arc<dyn WasmMemoryManager> {
+        self.memory
+            .as_ref()
+            .expect("Cannot access plugin memory before instantiation is complete")
+            .clone()
+    }
+    fn set_memory_manager(&mut self, manager: Arc<dyn WasmMemoryManager>) {
+        self.memory = Some(manager);
+    }
+    fn wasi(&mut self) -> &mut Option<WasiCtx> {
+        &mut self.wasi
+    }
+    fn shell(&self) -> RwLockReadGuard<'_, ShellState> {
+        self.shell.read().unwrap()
+    }
+
+    fn shell_mut(&mut self) -> RwLockWriteGuard<'_, ShellState> {
+        self.shell.write().unwrap()
+    }
+}

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -1,0 +1,162 @@
+use std::sync::{mpsc, Arc, RwLock};
+use std::thread::{spawn, JoinHandle};
+
+use serde_json::Value;
+use wasmtime::{Engine, WasmBacktraceDetails};
+
+use crate::state::shell::ShellState;
+
+use super::loader::RecursivePluginLoader;
+use super::plugin::Plugin;
+
+/// Handles running plugins in a seperate thread so as to not slow
+/// down the responsiveness of the main shell thread.
+pub struct PluginHost {
+    tunnel: mpsc::Sender<HookEvent>,
+}
+
+impl PluginHost {
+    /// Load plugins defined in the config and start running them in the background.
+    pub fn new(state: Arc<RwLock<ShellState>>) -> Self {
+        let plugin_engine = Engine::new(
+            wasmtime::Config::new()
+                .debug_info(true)
+                .wasm_backtrace_details(WasmBacktraceDetails::Enable),
+        )
+        .unwrap();
+
+        let plugin_loader = RecursivePluginLoader::new(plugin_engine, state);
+        let plugins = plugin_loader
+            .filter_map(|result| {
+                if let Err(err) = &result {
+                    eprintln!("rush: failed to load plugin: {err}");
+                }
+                result.ok()
+            })
+            .collect::<Vec<_>>();
+
+        let mut host = Self {
+            tunnel: Self::spawn_runner(plugins),
+        };
+        host.start();
+        host
+    }
+
+    /// Spawn a new plugin runner thread that listens for events on the returned hook.
+    fn spawn_runner(mut plugins: Vec<Box<dyn Plugin>>) -> mpsc::Sender<HookEvent> {
+        let (tx, rx) = mpsc::channel::<HookEvent>();
+
+        spawn(move || loop {
+            while let Ok(event) = rx.recv() {
+                let serialized_args = event
+                    .hook_params
+                    .iter()
+                    .map(|arg| serde_json::to_vec(arg).expect("Failed to serialize hook argument"))
+                    .collect::<Vec<_>>();
+                let arg_slices = serialized_args
+                    .iter()
+                    .map(|arg| arg.as_slice())
+                    .collect::<Vec<_>>();
+
+                let mut crashed_plugins = Vec::new();
+                let mut return_values = Vec::new();
+
+                for (index, plugin) in plugins.iter_mut().enumerate() {
+                    match &event.callback {
+                        HookBroadcastCallback::Value(_) => {
+                            let return_value =
+                                plugin.call_hook_with_return(&event.hook_name, &arg_slices);
+
+                            match return_value {
+                                Some(Ok(payload)) => {
+                                    return_values.push(PluginHookResponse {
+                                        payload,
+                                        plugin_name: plugin.name().to_owned(),
+                                    });
+                                }
+                                Some(Err(err)) => {
+                                    crashed_plugins.push((index, err));
+                                }
+                                None => {}
+                            }
+                        }
+                        HookBroadcastCallback::Empty(_) => {
+                            let return_value = plugin.call_hook(&event.hook_name, &arg_slices);
+
+                            if let Some(Err(err)) = return_value {
+                                crashed_plugins.push((index, err));
+                            }
+                        }
+                    }
+                }
+
+                // scan through crashed plugins from biggest index to smallest index
+                // so that remove() works properly
+                while let Some((index, crash)) = crashed_plugins.pop() {
+                    let plugin = plugins.remove(index);
+                    eprintln!("rush: plugin {} crashed: {crash}", plugin.name());
+                }
+
+                match event.callback {
+                    HookBroadcastCallback::Value(tx) => {
+                        _ = tx.send(return_values);
+                    }
+                    HookBroadcastCallback::Empty(tx) => {
+                        _ = tx.send(());
+                    }
+                }
+            }
+        });
+
+        tx
+    }
+
+    fn run_hook(&mut self, hook: &str, arguments: Vec<Value>) -> JoinHandle<()> {
+        let (tx, rx) = oneshot::channel::<()>();
+        self.tunnel
+            .send(HookEvent {
+                hook_name: hook.to_owned(),
+                hook_params: arguments,
+                callback: HookBroadcastCallback::Empty(tx),
+            })
+            .unwrap();
+        spawn(move || rx.recv().unwrap())
+    }
+
+    fn run_hook_with_return(
+        &mut self,
+        hook: &str,
+        arguments: Vec<Value>,
+    ) -> JoinHandle<Vec<PluginHookResponse>> {
+        let (tx, rx) = oneshot::channel::<Vec<PluginHookResponse>>();
+        self.tunnel
+            .send(HookEvent {
+                hook_name: hook.to_owned(),
+                hook_params: arguments,
+                callback: HookBroadcastCallback::Value(tx),
+            })
+            .unwrap();
+        spawn(move || rx.recv().unwrap())
+    }
+
+    fn start(&mut self) -> JoinHandle<()> {
+        self.run_hook("start", vec![])
+    }
+}
+
+struct HookEvent {
+    hook_name: String,
+    hook_params: Vec<Value>,
+    callback: HookBroadcastCallback,
+}
+struct PluginHookResponse {
+    payload: Value,
+    plugin_name: String,
+}
+
+enum HookBroadcastCallback {
+    /// The hook is not expected to return anything
+    Empty(oneshot::Sender<()>),
+    /// A return value is expected from the hook
+    Value(oneshot::Sender<Vec<PluginHookResponse>>),
+}

--- a/src/plugins/loader.rs
+++ b/src/plugins/loader.rs
@@ -1,0 +1,75 @@
+use std::{
+    io,
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
+
+use fs_err::{read, read_dir};
+use wasmtime::Engine;
+
+use crate::state::shell::ShellState;
+
+use super::plugin::{Plugin, WasmPluginBuilder};
+
+/// Searches paths for files ending in .wasm and loads them as plugins.
+pub struct RecursivePluginLoader {
+    paths: Vec<io::Result<PathBuf>>,
+    state: Arc<RwLock<ShellState>>,
+    engine: Engine,
+}
+
+impl RecursivePluginLoader {
+    pub fn new(engine: Engine, state: Arc<RwLock<ShellState>>) -> Self {
+        let plugin_paths = state.read().unwrap().config.plugin_paths.clone();
+        Self {
+            paths: plugin_paths.clone().into_iter().rev().map(Ok).collect(),
+            state,
+            engine,
+        }
+    }
+}
+
+impl Iterator for RecursivePluginLoader {
+    type Item = anyhow::Result<Box<dyn Plugin>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let path = match self.paths.pop()? {
+            Ok(path) => path,
+            Err(e) => return Some(Err(e.into())),
+        };
+
+        if path.is_dir() {
+            match read_dir(&path) {
+                Ok(dir) => {
+                    // We can only return 1 plugin per iteration so we need to
+                    // store the rest of the paths for later.
+                    self.paths
+                        .extend(dir.map(|result| result.map(|entry| entry.path())).filter(
+                            |path| {
+                                // filter out non-wasm files as they aren't plugins
+                                path.as_ref()
+                                    .map(|path| path.extension() == Some("wasm".as_ref()))
+                                    .unwrap_or(true)
+                            },
+                        ));
+                    return self.next();
+                }
+                Err(e) => return Some(Err(e.into())),
+            }
+        }
+
+        let bytes = match read(&path) {
+            Ok(bytes) => bytes,
+            Err(e) => return Some(Err(e.into())),
+        };
+
+        let plugin = WasmPluginBuilder::new(&self.engine, &bytes)
+            .name(path.file_name().unwrap().to_str().unwrap().to_string())
+            .state(self.state.clone())
+            .wasi(true)
+            .build();
+        Some(match plugin {
+            Ok(plugin) => Ok(Box::new(plugin)),
+            Err(e) => Err(e),
+        })
+    }
+}

--- a/src/plugins/memory.rs
+++ b/src/plugins/memory.rs
@@ -1,0 +1,43 @@
+pub mod manager;
+
+/// The address of a byte that may be controlled by the WASM engine.
+pub type WasmPtr = u32;
+
+/// A span of bytes that may be controlled by the WASM engine.
+/// This can be passed to a [`WasmMemoryManager`]
+/// to be read or written to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmSpan {
+    pub offset: WasmPtr,
+    pub length: WasmPtr,
+}
+
+impl WasmSpan {
+    /// Returns an i64 where the first half is the offset and the 2nd is the length
+    pub fn as_wide_pointer(&self) -> i64 {
+        let ptr = (self.offset as u64) << 32 | (self.length as u64);
+        ptr as i64
+    }
+
+    /// Parses an i64 where the first half is the offset and the 2nd is the length
+    pub fn from_wide_pointer(ptr: i64) -> Self {
+        let offset = (ptr >> 32) as u32;
+        let length = (ptr & 0xFFFFFFFF) as u32;
+        Self { offset, length }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wide_pointer() {
+        let span = WasmSpan {
+            offset: u32::MAX,
+            length: u32::MAX - 1,
+        };
+        let ptr = span.as_wide_pointer();
+        assert_eq!(WasmSpan::from_wide_pointer(ptr), span);
+    }
+}

--- a/src/plugins/memory.rs
+++ b/src/plugins/memory.rs
@@ -1,7 +1,14 @@
+use thiserror::Error;
+use wasmtime::Val;
+
 pub mod manager;
 
 /// The address of a byte that may be controlled by the WASM engine.
 pub type WasmPtr = u32;
+
+#[derive(Debug, Error)]
+#[error("Val must be an i64 to convert to a WasmSpan")]
+pub struct TryFromWasmError;
 
 /// A span of bytes that may be controlled by the WASM engine.
 /// This can be passed to a [`WasmMemoryManager`]
@@ -13,17 +20,22 @@ pub struct WasmSpan {
 }
 
 impl WasmSpan {
-    /// Returns an i64 where the first half is the offset and the 2nd is the length
-    pub fn as_wide_pointer(&self) -> i64 {
+    /// Returns an i64 where the first half is the offset of the memory and the 2nd is its length
+    pub fn to_wasm(&self) -> Val {
+        // For the plugin to use our data, it needs to know where to find
+        // it and how long it is. In this implementation, we represent buffers as
+        // a 64 bit number where the first half is the pointer to the buffer
+        // and the second half is its length.
         let ptr = (self.offset as u64) << 32 | (self.length as u64);
-        ptr as i64
+        Val::I64(ptr as i64)
     }
 
     /// Parses an i64 where the first half is the offset and the 2nd is the length
-    pub fn from_wide_pointer(ptr: i64) -> Self {
+    pub fn try_from_wasm(ptr: &Val) -> Result<Self, TryFromWasmError> {
+        let ptr = ptr.i64().ok_or(TryFromWasmError)? as u64;
         let offset = (ptr >> 32) as u32;
         let length = (ptr & 0xFFFFFFFF) as u32;
-        Self { offset, length }
+        Ok(Self { offset, length })
     }
 }
 
@@ -37,7 +49,7 @@ mod tests {
             offset: u32::MAX,
             length: u32::MAX - 1,
         };
-        let ptr = span.as_wide_pointer();
-        assert_eq!(WasmSpan::from_wide_pointer(ptr), span);
+        let ptr = span.to_wasm();
+        assert_eq!(WasmSpan::try_from_wasm(&ptr).unwrap(), span);
     }
 }

--- a/src/plugins/memory/manager.rs
+++ b/src/plugins/memory/manager.rs
@@ -1,0 +1,348 @@
+use std::{
+    marker::PhantomData,
+    ops::{Index, IndexMut},
+};
+
+use anyhow::Context;
+use wasmtime::{AsContextMut, Instance, Memory, Store, StoreContextMut, TypedFunc};
+
+use crate::plugins::StoreData;
+
+use super::{WasmPtr, WasmSpan};
+
+/// Controls sending and recieving data from the WebAssembly engine.
+pub trait WasmMemoryManager<T: Send + Sync = StoreData>: Send + Sync {
+    /// Create a buffer that can be accessed by the sandboxed WASM code
+    /// and will be automatically deallocated when dropped.
+    ///
+    /// One could use this method to send values:
+    ///
+    /// 1. Allocate a buffer in WASM memory.
+    /// 2. Copy data to the buffer
+    /// 3. Send the buffer's pointer to WASM code
+    fn alloc<'a>(&'a self, store: StoreContextMut<'a, T>, length: WasmPtr) -> WasmSlice<'a, T>;
+    /// [`WasmMemoryManager::alloc`] and copy a slice into the newly created buffer
+    fn copy<'a>(&'a self, store: StoreContextMut<'a, T>, buffer: &[u8]) -> WasmSlice<'a, T> {
+        let mut slice = self.alloc(store, buffer.len() as WasmPtr);
+        slice.as_mut().copy_from_slice(buffer);
+        slice
+    }
+    /// Create a view into existing owned WASM memory that will automatically deallocate when dropped.
+    fn get_from_raw<'a>(
+        &'a self,
+        store: StoreContextMut<'a, T>,
+        span: WasmSpan,
+    ) -> WasmSlice<'a, T>;
+    /// Create a view into existing borrowed WASM memory that will not automatically deallocate when dropped
+    fn view<'a>(&'a self, store: StoreContextMut<'a, T>, span: WasmSpan) -> WasmSlice<'a, T>;
+    fn raw_memory(&self) -> &Memory;
+    /// Deallocate memory at an address in the sandbox.
+    /// Prefer using [`WasmMemoryManager::alloc`], which does this automatically
+    /// on drop.
+    fn dealloc<'a>(&'a self, store: StoreContextMut<'a, T>, ptr: WasmPtr);
+}
+
+/// Controls sending and recieving data from the WebAssembly engine.
+/// This manager cooperates with the sandboxed allocator using
+/// plugin-defined alloc and dealloc functions to keep it from accidentally
+/// overwriting the memory we let the sandbox access. However, it does
+/// not work if plugins do not define these functions.
+pub struct CooperativeMemoryManager<T: Send + Sync> {
+    memory: Memory,
+    allocator: TypedFunc<WasmPtr, WasmPtr>,
+    deallocator: TypedFunc<WasmPtr, ()>,
+    _store_context: PhantomData<T>,
+}
+
+impl<T: Send + Sync> CooperativeMemoryManager<T> {
+    pub fn new(mut store: &mut Store<StoreData>, instance: &Instance) -> anyhow::Result<Self> {
+        Ok(Self {
+            memory: instance
+                .get_memory(&mut store, "memory")
+                .context("WASM code must expose its memory")?,
+            allocator: instance
+                .get_typed_func(&mut store, "mem_alloc")
+                .context("WASM code must expose a `mem_alloc` function")?,
+            deallocator: instance
+                .get_typed_func(&mut store, "mem_dealloc")
+                .context("WASM code must expose a `mem_free` function")?,
+            _store_context: PhantomData,
+        })
+    }
+}
+
+impl<T: Send + Sync> WasmMemoryManager<T> for CooperativeMemoryManager<T> {
+    fn alloc<'a>(&'a self, mut store: StoreContextMut<'a, T>, length: WasmPtr) -> WasmSlice<'a, T> {
+        let offset = self
+            .allocator
+            .call(&mut store, length)
+            .expect("wasm memory allocator failed");
+        WasmSlice {
+            span: WasmSpan { offset, length },
+            manager: self,
+            store,
+            owned: true,
+        }
+    }
+
+    fn view<'a>(&'a self, store: StoreContextMut<'a, T>, span: WasmSpan) -> WasmSlice<'a, T> {
+        WasmSlice {
+            span,
+            manager: self,
+            store,
+            owned: false,
+        }
+    }
+
+    fn get_from_raw<'a>(
+        &'a self,
+        store: StoreContextMut<'a, T>,
+        span: WasmSpan,
+    ) -> WasmSlice<'a, T> {
+        let mut slice = self.view(store, span);
+        slice.owned = true;
+        slice
+    }
+
+    fn raw_memory(&self) -> &Memory {
+        &self.memory
+    }
+
+    fn dealloc<'a>(&'a self, mut store: StoreContextMut<'a, T>, ptr: WasmPtr) {
+        self.deallocator
+            .call(&mut store, ptr)
+            .expect("wasm memory deallocator failed");
+    }
+}
+
+/// A view into a slice of memory controlled by the WASM engine
+pub struct WasmSlice<'a, T: Send + Sync> {
+    span: WasmSpan,
+    manager: &'a dyn WasmMemoryManager<T>,
+    store: StoreContextMut<'a, T>,
+    /// Controls if this memory will be deallocated when this struct is dropped
+    pub owned: bool,
+}
+
+impl<'a, T: Send + Sync> WasmSlice<'a, T> {
+    /// Prevent access to memory not within the bounds of this slice
+    fn guard_bounds(&self, offset: WasmPtr) {
+        if offset >= self.span.length {
+            panic!(
+                "attempt to access beyond the bounds of this slice: {offset} > {}",
+                self.span.length
+            );
+        }
+    }
+
+    /// Get the memory span that this struct references
+    #[must_use]
+    pub fn into_raw(mut self) -> WasmSpan {
+        self.owned = false;
+        self.span.clone()
+    }
+}
+
+impl<'a, T: Send + Sync> IndexMut<WasmPtr> for WasmSlice<'a, T> {
+    fn index_mut(&mut self, index: WasmPtr) -> &mut Self::Output {
+        self.guard_bounds(index);
+        &mut self.manager.raw_memory().data_mut(&mut self.store)[index as usize]
+    }
+}
+
+impl<'a, T: Send + Sync> Index<WasmPtr> for WasmSlice<'a, T> {
+    type Output = u8;
+
+    fn index(&self, index: WasmPtr) -> &Self::Output {
+        self.guard_bounds(index);
+        &self.manager.raw_memory().data(&self.store)[index as usize]
+    }
+}
+
+impl<'a, T: Send + Sync> AsRef<[u8]> for WasmSlice<'a, T> {
+    fn as_ref(&self) -> &[u8] {
+        let end_ptr = self.span.offset + self.span.length;
+        &self.manager.raw_memory().data(&self.store)[self.span.offset as usize..end_ptr as usize]
+    }
+}
+
+impl<'a, T: Send + Sync> AsMut<[u8]> for WasmSlice<'a, T> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        let end_ptr = self.span.offset + self.span.length;
+        &mut self.manager.raw_memory().data_mut(&mut self.store)
+            [self.span.offset as usize..end_ptr as usize]
+    }
+}
+
+impl<'a, T: Send + Sync> ToString for WasmSlice<'a, T> {
+    fn to_string(&self) -> String {
+        String::from_utf8(self.as_ref().to_vec()).unwrap()
+    }
+}
+
+impl<'a, T: Send + Sync> Drop for WasmSlice<'a, T> {
+    fn drop(&mut self) {
+        if self.owned {
+            self.manager
+                .dealloc(self.store.as_context_mut(), self.span.offset)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use wasmtime::{AsContextMut, Engine, MemoryType, Store};
+
+    fn bootstrap() -> (Store<MockState>, MockMemoryManger) {
+        let engine = Engine::default();
+        let mut store = Store::new(&engine, MockState::default());
+        let memory = Memory::new(&mut store, MemoryType::new(1, None)).unwrap();
+        (store, MockMemoryManger { memory })
+    }
+
+    struct MockMemoryManger {
+        memory: Memory,
+    }
+
+    #[derive(Default)]
+    struct MockState {
+        allocated_spans: HashMap<WasmPtr, WasmPtr>,
+        memory_offset: WasmPtr,
+    }
+
+    impl WasmMemoryManager<MockState> for MockMemoryManger {
+        fn alloc<'a>(
+            &'a self,
+            mut store: StoreContextMut<'a, MockState>,
+            length: WasmPtr,
+        ) -> WasmSlice<'a, MockState> {
+            const PAGE_SIZE: u64 = 65536;
+            let offset = store.data().memory_offset;
+            if (offset + length) as u64 > PAGE_SIZE * self.memory.size(&store) {
+                self.memory
+                    .grow(&mut store, (length as u64).div_ceil(PAGE_SIZE))
+                    .unwrap();
+            }
+
+            let span = WasmSpan {
+                offset: store.data().memory_offset,
+                length,
+            };
+
+            {
+                let data = store.data_mut();
+                data.allocated_spans.insert(offset, span.length);
+                data.memory_offset += length;
+            }
+
+            WasmSlice {
+                span,
+                manager: self,
+                store,
+                owned: true,
+            }
+        }
+
+        fn dealloc<'a>(&'a self, mut store: StoreContextMut<'a, MockState>, ptr: WasmPtr) {
+            let data = store.data_mut();
+            data.allocated_spans
+                .remove(&ptr)
+                .expect("Invalid address in dealloc");
+        }
+
+        fn raw_memory(&self) -> &Memory {
+            &self.memory
+        }
+
+        fn get_from_raw<'a>(
+            &'a self,
+            store: StoreContextMut<'a, MockState>,
+            span: WasmSpan,
+        ) -> WasmSlice<'a, MockState> {
+            let mut slice = self.view(store, span);
+            slice.owned = true;
+            slice
+        }
+
+        fn view<'a>(
+            &'a self,
+            store: StoreContextMut<'a, MockState>,
+            span: WasmSpan,
+        ) -> WasmSlice<'a, MockState> {
+            WasmSlice {
+                span,
+                manager: self,
+                store,
+                owned: false,
+            }
+        }
+    }
+
+    #[test]
+    fn test_slice_valid_access() {
+        let (mut store, manager) = bootstrap();
+        let mut slice = manager.alloc(store.as_context_mut(), 10);
+        _ = slice[0];
+        slice[0] = 1;
+        _ = slice[9];
+        slice[9] = 1;
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_slice_invalid_access() {
+        let (mut store, manager) = bootstrap();
+        let slice = manager.alloc(store.as_context_mut(), 10);
+        _ = slice[10];
+    }
+
+    #[test]
+    fn test_slice_read_and_write() {
+        let (mut store, manager) = bootstrap();
+        let mut slice = manager.alloc(store.as_context_mut(), 2);
+        slice[0] = 1;
+        slice[1] = 2;
+        assert_eq!(slice[0], 1);
+        assert_eq!(slice[1], 2);
+    }
+
+    #[test]
+    fn test_slice_to_string() {
+        let (mut store, manager) = bootstrap();
+        let mut slice = manager.alloc(store.as_context_mut(), 2);
+        slice[0] = b'a';
+        slice[1] = b'b';
+        assert_eq!(slice.to_string(), "ab");
+    }
+
+    #[test]
+    fn test_slice_into_raw() {
+        let (mut store, manager) = bootstrap();
+        let slice = manager.alloc(store.as_context_mut(), 2);
+        let raw = slice.into_raw();
+        assert_eq!(raw.offset, 0);
+        assert_eq!(raw.length, 2);
+    }
+
+    #[test]
+    fn test_slice_drop() {
+        let (mut store, manager) = bootstrap();
+        let slice = manager.alloc(store.as_context_mut(), 2);
+        let raw = slice.into_raw();
+        assert_eq!(store.data().allocated_spans.len(), 1);
+        let slice = manager.get_from_raw(store.as_context_mut(), raw);
+        drop(slice);
+        assert_eq!(store.data().allocated_spans.len(), 0);
+    }
+
+    #[test]
+    fn test_slice_drop_unowned() {
+        let (mut store, manager) = bootstrap();
+        let mut slice = manager.alloc(store.as_context_mut(), 2);
+        slice.owned = false;
+        drop(slice);
+        assert_eq!(store.data().allocated_spans.len(), 1);
+    }
+}

--- a/src/plugins/memory/manager.rs
+++ b/src/plugins/memory/manager.rs
@@ -222,7 +222,7 @@ mod tests {
             let offset = store.data().memory_offset;
             if (offset + length) as u64 > PAGE_SIZE * self.memory.size(&store) {
                 self.memory
-                    .grow(&mut store, (length as u64).div_ceil(PAGE_SIZE))
+                    .grow(&mut store, length as u64 / PAGE_SIZE + 1)
                     .unwrap();
             }
 

--- a/src/plugins/plugin.rs
+++ b/src/plugins/plugin.rs
@@ -76,7 +76,13 @@ impl<'a> WasmPluginBuilder<'a> {
         let mut linker = Linker::new(self.engine);
 
         let context = WasmPluginContext {
-            wasi: self.wasi.then(|| WasiCtxBuilder::new().build()),
+            wasi: self.wasi.then(|| {
+                WasiCtxBuilder::new()
+                    .inherit_stdio()
+                    .inherit_env()
+                    .unwrap()
+                    .build()
+            }),
             shell: self.state.context("Shell state not provided to plugin")?,
             memory: None,
         };

--- a/src/plugins/plugin.rs
+++ b/src/plugins/plugin.rs
@@ -1,0 +1,222 @@
+use std::{
+    rc::Rc,
+    sync::{Arc, RwLock},
+};
+
+use anyhow::Context;
+use serde_json::Value;
+use wasmtime::{AsContextMut, Engine, Instance, Linker, Module, Store, Val, ValType};
+use wasmtime_wasi::WasiCtxBuilder;
+
+use crate::state::shell::ShellState;
+
+use super::{
+    memory::{manager::CooperativeMemoryManager, WasmSpan},
+    StoreData, WasmPluginContext,
+};
+
+pub trait Plugin: Send {
+    /// Returns the name of the plugin - this is usually the file it was loaded from
+    fn name(&self) -> &str;
+    /// Run a function defined by the plugin.
+    /// Accepts a pre-serialized argument list of JSON data, so as to not cause
+    /// unneccesary serialization.
+    fn call_hook(&mut self, name: &str, arguments: &[&[u8]]) -> Option<anyhow::Result<()>>;
+    /// Run a function defined by the plugin and capture its return value.
+    fn call_hook_with_return(
+        &mut self,
+        name: &str,
+        arguments: &[&[u8]],
+    ) -> Option<anyhow::Result<Value>>;
+}
+
+pub struct WasmPluginBuilder<'a> {
+    name: Option<String>,
+    bytes: &'a [u8],
+    wasi: bool,
+    engine: &'a Engine,
+    state: Option<Arc<RwLock<ShellState>>>,
+}
+
+impl<'a> WasmPluginBuilder<'a> {
+    pub fn new(engine: &'a Engine, bytes: &'a [u8]) -> Self {
+        Self {
+            name: None,
+            bytes,
+            wasi: false,
+            engine,
+            state: None,
+        }
+    }
+
+    pub fn unnamed(mut self) -> Self {
+        self.name = Some("<unnamed plugin>".to_string());
+        self
+    }
+
+    pub fn name(mut self, name: String) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn wasi(mut self, wasi: bool) -> Self {
+        self.wasi = wasi;
+        self
+    }
+
+    pub fn state(mut self, state: Arc<RwLock<ShellState>>) -> Self {
+        self.state = Some(state);
+        self
+    }
+
+    pub fn build(self) -> anyhow::Result<WasmPlugin> {
+        let name = self.name.context("Plugin name not set")?;
+
+        let module = Module::new(self.engine, self.bytes)?;
+        let mut linker = Linker::new(self.engine);
+
+        let context = WasmPluginContext {
+            wasi: self.wasi.then(|| WasiCtxBuilder::new().build()),
+            shell: self.state.context("Shell state not provided to plugin")?,
+            memory: None,
+        };
+        if self.wasi {
+            wasmtime_wasi::add_to_linker(&mut linker, |ctx: &mut StoreData| {
+                ctx.wasi().as_mut().unwrap()
+            })?;
+        }
+        let mut store = Store::<StoreData>::new(self.engine, Box::new(context));
+        let instance = linker.instantiate(&mut store, &module)?;
+        let memory_manager = CooperativeMemoryManager::new(&mut store, &instance)?;
+        store
+            .data_mut()
+            .set_memory_manager(Arc::new(memory_manager));
+
+        Ok(WasmPlugin {
+            name,
+            instance: linker.instantiate(&mut store, &module)?,
+            store,
+        })
+    }
+}
+
+pub struct WasmPlugin {
+    name: String,
+    instance: Instance,
+    store: Store<StoreData>,
+}
+
+impl WasmPlugin {
+    fn buffers_to_pointers(&mut self, values: &[&[u8]]) -> Vec<Val> {
+        // For the plugin to find our arguments, it needs to know where to find
+        // it and how long it is. In this implementation, we split each buffer into
+        // an 64 bit number where the first half is the pointer to the buffer
+        // and the second half is its length
+        // Example:
+        // `fn after_command(stdout: String, stderr: String)`
+        // becomes:
+        // `fn(stdout: i64, stderr: i64)`
+        values
+            .iter()
+            .map(|buffer| {
+                self.store
+                    .data()
+                    .memory()
+                    .copy(self.store.as_context_mut(), buffer)
+                    .into_raw()
+                    .as_wide_pointer()
+            })
+            .map(Val::I64)
+            .collect()
+    }
+}
+
+impl Plugin for WasmPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn call_hook(&mut self, name: &str, arguments: &[&[u8]]) -> Option<anyhow::Result<()>> {
+        let hook = self.instance.get_func(&mut self.store, name)?;
+
+        if hook.ty(&self.store).results().len() != 0 {
+            return Some(Err(anyhow::anyhow!("Hook {name} may not return a value")));
+        }
+
+        let arg_pointers = self.buffers_to_pointers(arguments);
+
+        if let Err(err) = hook.call(&mut self.store, &arg_pointers, &mut []) {
+            return Some(Err(err));
+        }
+
+        Some(Ok(()))
+    }
+    fn call_hook_with_return(
+        &mut self,
+        name: &str,
+        arguments: &[&[u8]],
+    ) -> Option<anyhow::Result<Value>> {
+        let hook = self.instance.get_func(&mut self.store, name)?;
+
+        let hook_type = hook.ty(&self.store);
+        if hook_type.results().len() != 1 || hook_type.results().next() != Some(ValType::I64) {
+            return Some(Err(anyhow::anyhow!("Hook {name} must return an i64")));
+        }
+
+        let arg_pointers = self.buffers_to_pointers(arguments);
+
+        let mut return_values = [Val::null()];
+        if let Err(err) = hook.call(&mut self.store, &arg_pointers, &mut return_values) {
+            return Some(Err(err));
+        }
+
+        let memory_span = WasmSpan::from_wide_pointer(return_values[0].unwrap_i64());
+        let buffer = self
+            .store
+            .data()
+            .memory()
+            .view(self.store.as_context_mut(), memory_span)
+            .as_ref()
+            .to_vec();
+        Some(serde_json::from_slice(&buffer).context("Hook returned invalid json"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::shell::ShellState;
+    use std::sync::Arc;
+    use wasmtime::Engine;
+
+    #[test]
+    fn can_create_plugin_and_call_hook() {
+        let engine = Engine::default();
+        let mut plugin = WasmPluginBuilder::new(
+            &engine,
+            r#"
+            (module
+                (func $test (param) (result))
+                (export "test" (func $test))
+                (memory (export "memory") 1)
+                (func $mem_alloc (param i32) (result i32)
+                    unreachable
+                )
+                (func $mem_dealloc (param i32)
+                    unreachable
+                )
+                (export "mem_alloc" (func $mem_alloc))
+                (export "mem_dealloc" (func $mem_dealloc))
+            )
+            "#
+            .as_bytes(),
+        )
+        .unnamed()
+        .wasi(true)
+        .state(ShellState::new().unwrap())
+        .build()
+        .unwrap();
+
+        let result = plugin.call_hook("test", &[]);
+        assert!(matches!(result, Some(Ok(()))));
+    }
+}

--- a/src/state/errors.rs
+++ b/src/state/errors.rs
@@ -17,10 +17,9 @@ pub enum ShellError {
     #[error("Next directory does not exist")]
     NoNextDirectory,
     #[error("Failed to open configuration file: {0}")]
-    // ? Should these be Strings or Path/PathBuf?
-    FailedToOpenConfigFile(String),
+    FailedToOpenConfigFile(PathBuf),
     #[error("Failed to read configuration file: {0}")]
-    FailedToReadConfigFile(String),
+    FailedToReadConfigFile(PathBuf),
     #[error("Unknown error")]
     Uncategorized,
 }

--- a/src/state/shell.rs
+++ b/src/state/shell.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, RwLock};
+
 use anyhow::Result;
 use crossterm::style::Stylize;
 
@@ -14,16 +16,16 @@ pub struct ShellState {
 }
 
 impl ShellState {
-    pub fn new() -> Result<Self> {
+    pub fn new() -> Result<Arc<RwLock<Self>>> {
         let config =
             Configuration::from_file("./config/config.rush").unwrap_or(Configuration::default());
 
-        Ok(Self {
+        Ok(Arc::new(RwLock::new(Self {
             environment: Environment::new()?,
             config,
             last_command_succeeded: true,
             should_exit: false,
-        })
+        })))
     }
 
     // Generates the prompt string used by the REPL


### PR DESCRIPTION
#36 again, but this time hopefully simpler

- Adds PluginHost (and implementation details) for loading and communicating with plugins
- ShellState is now in a RwLock so that it can be shared across threads
- FailedToReadConfigFile and FailedToOpenConfigFile now use PathBuf