### PR TITLE
feat(builtin): Show different times (eg. Modified, Created, Accessed) and hide categories in `ls`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -766,12 +766,12 @@ macro_rules! clap_handle {
         match $expr {
             Ok(val) => val,
             Err(e) => {
-                eprintln!("{}", e.render().ansi());    
+                eprintln!("{}", e.render().ansi());
                 match e.kind() {
                     clap::error::ErrorKind::DisplayHelp => return crate::errors::Result::Ok(()),
                     _ => return crate::errors::Result::Err(builtin_err!(CouldNotParseArgs)),
                 }
-            },
+            }
         }
     };
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -531,6 +531,30 @@ pub enum FileError {
     UnreadableFileName(PathBuf),
 
     /// OVERVIEW
+    /// This error occurs when the shell cannot read the permissions of a file or directory.
+    ///
+    /// CAUSE
+    /// - Inadequate user permissions.
+    /// - File or directory doesn't exist.
+    ///
+    /// SOLUTION
+    /// - Enure the user has adequate permissions to read the file.
+    /// - Enure the directory or file exists.
+    UnreadablePermissions(PathBuf),
+
+    /// OVERVIEW
+    /// This error occurs when a files metadata cannot be read.
+    ///
+    /// CAUSE
+    /// - Inadequate user permissions.
+    /// - File doesn't exist
+    ///
+    /// SOLUTION
+    /// - Enure the user has adequate permissions to read the file.
+    /// - Enure the file exists.
+    UnreadableMetadata(PathBuf),
+
+    /// OVERVIEW
     /// This error occurs when the shell is unable to read the contents of a directory.
     ///
     /// CAUSE
@@ -689,6 +713,20 @@ impl Display for FileError {
                 write!(
                     f,
                     "Could not determine file name of path '{}'",
+                    path.display()
+                )
+            }
+            UnreadablePermissions(path) => {
+                write!(
+                    f,
+                    "Could not get permissions at path '{}'",
+                    path.display()
+                )
+            }
+            UnreadableMetadata(path) => {
+                write!(
+                    f,
+                    "Could not read metadata at path '{}'",
                     path.display()
                 )
             }

--- a/src/exec/builtins/args.rs
+++ b/src/exec/builtins/args.rs
@@ -30,25 +30,37 @@ pub struct ChangeDirectoryArgs {
 pub struct ListDirectoryArgs {
     #[arg(short = 'a', long = "all", help = "Show hidden files and directories")]
     pub show_hidden: bool,
-    #[arg(short = 'l', long = "long", help = "Show files with details as a table")]
+    #[arg(
+        short = 'l',
+        long = "long",
+        help = "Show file and directory names in a table with additional information"
+    )]
     pub long_view: bool,
-    #[arg(short = 'o', long = "octal-permissions", help = "Use octal permissions instead of string representation")]
+    #[arg(
+        short = 'O',
+        long = "octal-permissions",
+        help = "Use octal permission notation instead of string notation"
+    )]
     pub octal_permissions: bool,
-    #[arg(short = 'm', long = "modified", help = "Use modified timestamp")]
+    #[arg(short = 'M', long = "date-modified", help = "Use modified timestamp")]
     pub use_modified_time: bool,
-    #[arg(short = 'U', long = "created", help = "Use created timestamp")]
+    #[arg(short = 'C', long = "date-created", help = "Use created timestamp")]
     pub use_created_time: bool,
-    #[arg(short = 'u', long = "accessed", help = "Use accessed timestamp")]
+    #[arg(short = 'U', long = "date-accessed", help = "Use accessed timestamp")]
     pub use_accessed_time: bool,
     #[arg(long = "hide-timestamps", help = "Do not show the timestamp field")]
     pub hide_timestamps: bool,
-    #[arg(long = "permission-seperator", help = "Show sperators for each permission group (eg. Current user, current group, and other users and groups)")]
+    #[arg(
+        short = 's',
+        long = "permission-separator",
+        help = "Show separators for permission types (all users, owner, group, other)"
+    )]
     pub permission_seperator: bool,
-    #[arg(long = "hide-permissions", help = "Do not show permissions field")]
+    #[arg(long = "hide-permissions", help = "Do not show the permissions field")]
     pub hide_permissions: bool,
-    #[arg(long = "hide-user",  help = "Do not show user field")]
+    #[arg(long = "hide-user", help = "Do not show the user field")]
     pub hide_user: bool,
-    #[arg(long = "hide-file-sizes", help = "Do not show file size field")]
+    #[arg(long = "hide-file-sizes", help = "Do not show the file size field")]
     pub hide_file_sizes: bool,
     #[arg(help = "The path of the directory to read")]
     pub path: Option<PathBuf>,

--- a/src/exec/builtins/args.rs
+++ b/src/exec/builtins/args.rs
@@ -34,8 +34,22 @@ pub struct ListDirectoryArgs {
     pub long_view: bool,
     #[arg(short = 'o', long = "octal-permissions", help = "Use octal permissions instead of string representation")]
     pub octal_permissions: bool,
+    #[arg(short = 'm', long = "modified", help = "Use modified timestamp")]
+    pub use_modified_time: bool,
+    #[arg(short = 'U', long = "created", help = "Use created timestamp")]
+    pub use_created_time: bool,
+    #[arg(short = 'u', long = "accessed", help = "Use accessed timestamp")]
+    pub use_accessed_time: bool,
+    #[arg(long = "hide-timestamps", help = "Do not show the timestamp field")]
+    pub hide_timestamps: bool,
     #[arg(long = "permission-seperator", help = "Show sperators for each permission group (eg. Current user, current group, and other users and groups)")]
     pub permission_seperator: bool,
+    #[arg(long = "hide-permissions", help = "Do not show permissions field")]
+    pub hide_permissions: bool,
+    #[arg(long = "hide-user",  help = "Do not show user field")]
+    pub hide_user: bool,
+    #[arg(long = "hide-file-sizes", help = "Do not show file size field")]
+    pub hide_file_sizes: bool,
     #[arg(help = "The path of the directory to read")]
     pub path: Option<PathBuf>,
 }

--- a/src/exec/builtins/functions.rs
+++ b/src/exec/builtins/functions.rs
@@ -216,7 +216,7 @@ fn list_directory_long(
     if !hide_file_sizes {
         for i in &item {
             let path = path_to_read.join(i);
-            let file_size = std::fs::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.size();
+            let file_size = fs_err::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.size();
             let formatted_fsize = Size::from_bytes(file_size).to_string();
 
             file_size_len_last = formatted_fsize.len();
@@ -244,7 +244,7 @@ fn list_directory_long(
         let permission_octal = {
             let x = format!(
                 "{:o}",
-                std::fs::metadata(path.clone())
+                fs_err::metadata(path.clone())
                     .replace_err(|| file_err!(UnreadableMetadata: path_to_read))?
                     .permissions()
                     .mode()
@@ -300,13 +300,13 @@ fn list_directory_long(
             DirectoryListPermissionMode::Hidden => "".to_string().white(),
         };
 
-        let file_size = std::fs::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.size();
+        let file_size = fs_err::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.size();
         let formatted_fsize = Size::from_bytes(file_size).to_string();
         let timestamp = match timestamp {
             DirectoryListTimestampMode::Modified => format!(
                 "{}",
                 DateTime::<Local>::from(
-                    std::fs::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.modified().unwrap()
+                    fs_err::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.modified().replace_err(|| file_err!(UnreadableMetadata: path_to_read))?
                 )
                 .format("%b %d %Y %T")
             )
@@ -314,7 +314,7 @@ fn list_directory_long(
             DirectoryListTimestampMode::Created => format!(
                 "{}",
                 DateTime::<Local>::from(
-                    std::fs::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.created().unwrap()
+                    fs_err::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.created().replace_err(|| file_err!(UnreadableMetadata: path_to_read))?
                 )
                 .format("%b %d %Y %T")
             )
@@ -322,7 +322,7 @@ fn list_directory_long(
             DirectoryListTimestampMode::Accessed => format!(
                 "{}",
                 DateTime::<Local>::from(
-                    std::fs::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.accessed().unwrap()
+                    fs_err::metadata(path.clone()).replace_err(|| file_err!(UnreadableMetadata: path_to_read))?.accessed().replace_err(|| file_err!(UnreadableMetadata: path_to_read))?
                 )
                 .format("%b %d %Y %T")
             )


### PR DESCRIPTION
You can now change which timestamp is displayed in `ls` by using the following:

`-m`: Modified time
`-U`: Created time
`-u`: Accessed time

You may also hide desired categories with:

`--hide-timestamps`: Hide timestamps
`--hide-permissions`: Hide permissions
`--hide-user`: Hide file owner
`--hide-file-sizes`: Hide file sizes